### PR TITLE
Update ember-fastclick.js

### DIFF
--- a/lib/ember-fastclick.js
+++ b/lib/ember-fastclick.js
@@ -44,14 +44,16 @@
 			if (!touch.enabled) return;
 			
 			var self = this,
-				moved;
+				moved, originalClass;
 			rootElement.delegate('.ember-view', event + '.ember', function(evt, triggeringManager) {		
 				// Track touch events to see how far the user's finger has moved
 				// If it is > 20 it will not trigger a click event
 
 				switch(evt.type) {
 					// Remember our starting point
-					case 'touchstart':					
+					case 'touchstart':	
+						self.originalClass = this.className;			
+						this.className += ' pseudo-active';				
 						touch.start = true;
 						touch.x = evt.originalEvent.touches[0].clientX;
 						touch.y = evt.originalEvent.touches[0].clientY;
@@ -71,6 +73,7 @@
 					// Check end point
 					case 'touchend':
 						if (touch.start) {
+							this.className = self.originalClass;
 							moved = Math.max(Math.abs(evt.originalEvent.changedTouches[0].clientX - touch.x), 
 										Math.abs(evt.originalEvent.changedTouches[0].clientY - touch.y));
 							if (moved < 20) {


### PR DESCRIPTION
Added a class called "pseudo-active" to elements being touched, so we can apply css rules to them since the normal ":active" css pseudo class isn't applied.
