### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Ember.js Touch Helpers
+# Ember.js Touch Helpers
 =============
 
-##ember-fastclick.js
+## ember-fastclick.js
 Allows you to use a view's click function or {{action}} in a touch enviroment without the 300ms delay.
 Elements have the name 'pseudo-active' while being touched. Normal active state doesn't work.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
